### PR TITLE
allow ENV vars for email and app-password input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /TEST_CREDS.TXT
 
 *.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ to get access to.
 
 2. Run ```python path-to-gmail-backup/dobackup.py``` and put in your Gmail address and password when prompted.
 
+2. Set env vars `DOBACKUP_GMAIL_APP_USER` and `DOBACKUP_GMAIL_APP_PWD` if you want to avoid manual input.
+
 3. Your emails will be downloaded to the current directory and named 1.eml, 2.eml, etc.
 
 4. Numbering is not necessarily sequential.  The file is named after the message's "unique id", which,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ to get access to.
 
 2. Run ```python path-to-gmail-backup/dobackup.py``` and put in your Gmail address and password when prompted.
 
-2. Set env vars `DOBACKUP_GMAIL_APP_USER` and `DOBACKUP_GMAIL_APP_PWD` if you want to avoid manual input.
+    2. Set env vars `DOBACKUP_GMAIL_APP_USER` and `DOBACKUP_GMAIL_APP_PWD` if you want to avoid manual input.
+
+    2. Set env vars `DOBACKUP_GMAIL_LABEL` and `DOBACKUP_SAVE_FOLDER` if you want to target subsets of your email account, and save them someplace specific.
 
 3. Your emails will be downloaded to the current directory and named 1.eml, 2.eml, etc.
 

--- a/dobackup.py
+++ b/dobackup.py
@@ -39,13 +39,20 @@ def get_credentials():
     pwd = os.environ.get("DOBACKUP_GMAIL_APP_PWD", None) or getpass.getpass("Gmail password: ")
     return user, pwd
 
+def gmail_folder():
+    return os.environ.get("DOBACKUP_GMAIL_LABEL", GMAIL_FOLDER_NAME) 
+
+def save_folder_path():
+    folder = os.environ.get("DOBACKUP_SAVE_FOLDER", "") # i.e. "./"
+    os.makedirs(folder, exist_ok=True)
+    return folder
 
 def do_backup():
     svr = imaplib.IMAP4_SSL('imap.gmail.com')
     user, pwd = get_credentials()
     svr.login(user, pwd)
 
-    resp, [countstr] = svr.select(GMAIL_FOLDER_NAME, True)
+    resp, [countstr] = svr.select(gmail_folder(), True)
     count = int(countstr)
 
     existing_files = os.listdir(".")
@@ -68,7 +75,8 @@ def do_backup():
     for i in range(ungotten, count + 1):
         uid = getUIDForMessage(svr, i)
         print "Downloading %d/%d (UID: %s)" % (i, count, uid)
-        downloadMessage(svr, i, uid + '.eml')
+        filepath = save_folder_path() + uid + '.eml'
+        downloadMessage(svr, i, filepath)
 
     svr.close()
     svr.logout()

--- a/dobackup.py
+++ b/dobackup.py
@@ -44,7 +44,7 @@ def gmail_folder():
 
 def save_folder_path():
     folder = os.environ.get("DOBACKUP_SAVE_FOLDER", '.') # i.e. "./"
-    if (not folder or (folder and folder == '')):
+    if not folder:
         raise ValueError("target folder missing")
     if os.path.isfile(folder):
         raise ValueError("a file exists at your target path")
@@ -82,7 +82,7 @@ def do_backup():
     for i in range(ungotten, count + 1):
         uid = getUIDForMessage(svr, i)
         print "Downloading %d/%d (UID: %s)" % (i, count, uid)
-        filepath = ios.path.join(target_folder, uid + '.eml')
+        filepath = os.path.join(target_folder, uid + '.eml')
         downloadMessage(svr, i, filepath)
 
     svr.close()

--- a/dobackup.py
+++ b/dobackup.py
@@ -43,11 +43,18 @@ def gmail_folder():
     return os.environ.get("DOBACKUP_GMAIL_LABEL", GMAIL_FOLDER_NAME) 
 
 def save_folder_path():
-    folder = os.environ.get("DOBACKUP_SAVE_FOLDER", "") # i.e. "./"
-    os.makedirs(folder, exist_ok=True)
+    folder = os.environ.get("DOBACKUP_SAVE_FOLDER", '.') # i.e. "./"
+    if (not folder or (folder and folder == '')):
+        raise ValueError("target folder missing")
+    if os.path.isfile(folder):
+        raise ValueError("a file exists at your target path")
+
+    if not os.path.exists(folder):
+        os.makedirs(folder)
     return folder
 
 def do_backup():
+    target_folder = save_folder_path()
     svr = imaplib.IMAP4_SSL('imap.gmail.com')
     user, pwd = get_credentials()
     svr.login(user, pwd)
@@ -75,7 +82,7 @@ def do_backup():
     for i in range(ungotten, count + 1):
         uid = getUIDForMessage(svr, i)
         print "Downloading %d/%d (UID: %s)" % (i, count, uid)
-        filepath = save_folder_path() + uid + '.eml'
+        filepath = ios.path.join(target_folder, uid + '.eml')
         downloadMessage(svr, i, filepath)
 
     svr.close()

--- a/dobackup.py
+++ b/dobackup.py
@@ -35,8 +35,8 @@ def UIDFromFilename(fname):
 
 
 def get_credentials():
-    user = raw_input("Gmail address: ")
-    pwd = getpass.getpass("Gmail password: ")
+    user = os.environ.get("DOBACKUP_GMAIL_APP_USER", None) or raw_input("Gmail address: ")
+    pwd = os.environ.get("DOBACKUP_GMAIL_APP_PWD", None) or getpass.getpass("Gmail password: ")
     return user, pwd
 
 


### PR DESCRIPTION
When re-running the script, manual entry is a pain. 

* safely check for env vars, and use them
   * email username
   * app-specific password
   * target label
   * target save path
* fallback to 
   * realtime user input, or 
   * sane (and same) defaults
* README